### PR TITLE
Continue migration to typed smtml

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -8,8 +8,8 @@ let
     src = pkgs.fetchFromGitHub {
       owner = "formalsec";
       repo = "smtml";
-      rev = "c5cd4c6db8e0fab9b8cff51e0c764fb5974774ef";
-      hash = "sha256-mQa22QLJ3Cg+5VADR96Drt4PAoBDt5JwVo0BgFdtDnw=";
+      rev = "d0db3aadc3710a293327b6517bdd16047ac7e277";
+      hash = "sha256-NGMR+hOYF8v6W+0niBT36ATdsgE8X73IZL8oxTpN4Sc=";
     };
   });
   synchronizer = pkgs.ocamlPackages.synchronizer.overrideAttrs (old: {

--- a/src/cmd/cmd_iso.ml
+++ b/src/cmd/cmd_iso.ml
@@ -51,7 +51,9 @@ let binaryen_fuzzing_support_module weird_log_i64 =
   { Extern.Module.functions; func_type = Symbolic_extern_func.extern_type }
 
 let emscripten_fuzzing_support_module () =
-  let temp_ret_0 = ref (Smtml.Expr.value (Smtml.Value.Int 0)) in
+  let temp_ret_0 =
+    ref (Smtml.Expr.value (Smtml.Value.Int 0) |> Smtml.Typed.unsafe)
+  in
   let set_temp_ret_0 x =
     temp_ret_0 := x;
     Symbolic_choice.return ()

--- a/src/symbolic/symbolic_boolean.ml
+++ b/src/symbolic/symbolic_boolean.ml
@@ -1,20 +1,21 @@
 type t = bool Smtml.Typed.t
 
-let false_ = Smtml.Typed.false_
+let false_ = Smtml.Typed.Bool.false_
 
-let true_ = Smtml.Typed.true_
+let true_ = Smtml.Typed.Bool.true_
 
 let of_concrete (i : bool) : t = if i then true_ else false_ [@@inline]
 
-let not e = Smtml.Typed.not_ e [@@inline]
+let not e = Smtml.Typed.Bool.not e [@@inline]
 
-let or_ e1 e2 = Smtml.Typed.or_ e1 e2 [@@inline]
+let or_ e1 e2 = Smtml.Typed.Bool.or_ e1 e2 [@@inline]
 
-let and_ e1 e2 = Smtml.Typed.and_ e1 e2 [@@inline]
+let and_ e1 e2 = Smtml.Typed.Bool.and_ e1 e2 [@@inline]
 
-let pp fmt e = Smtml.Expr.pp fmt (Smtml.Typed.raw e)
+let pp fmt e = Smtml.Typed.Bool.pp fmt e [@@inline]
 
-let ite c ~if_true ~if_false = Smtml.Typed.ite c if_true if_false [@@inline]
+let ite c ~if_true ~if_false = Smtml.Typed.Bool.ite c if_true if_false
+[@@inline]
 
 let of_expr v = Smtml.Typed.unsafe v [@@inline]
 

--- a/src/symbolic/symbolic_f32.ml
+++ b/src/symbolic/symbolic_f32.ml
@@ -1,7 +1,5 @@
 type t = Smtml.Typed.float32 Smtml.Typed.t
 
-let ty = Smtml.Ty.Ty_fp 32
-
 let of_concrete (f : Float32.t) : t = Smtml.Typed.Float32.v (Float32.to_bits f)
 
 let zero = of_concrete Float32.zero
@@ -12,14 +10,13 @@ let neg x = Smtml.Typed.Float32.neg x
 
 let sqrt x = Smtml.Typed.Float32.sqrt x
 
-let ceil x = Smtml.Expr.unop ty Ceil (Smtml.Typed.raw x) |> Smtml.Typed.unsafe
+let ceil x = Smtml.Typed.Float32.ceil x
 
-let floor x = Smtml.Expr.unop ty Floor (Smtml.Typed.raw x) |> Smtml.Typed.unsafe
+let floor x = Smtml.Typed.Float32.floor x
 
-let trunc x = Smtml.Expr.unop ty Trunc (Smtml.Typed.raw x) |> Smtml.Typed.unsafe
+let trunc x = Smtml.Typed.Float32.trunc x
 
-let nearest x =
-  Smtml.Expr.unop ty Nearest (Smtml.Typed.raw x) |> Smtml.Typed.unsafe
+let nearest x = Smtml.Typed.Float32.nearest x
 
 let add x y = Smtml.Typed.Float32.add x y
 
@@ -33,15 +30,11 @@ let min x y = Smtml.Typed.Float32.min x y
 
 let max x y = Smtml.Typed.Float32.max x y
 
-let copy_sign x y =
-  Smtml.Expr.binop ty Copysign (Smtml.Typed.raw x) (Smtml.Typed.raw y)
-  |> Smtml.Typed.unsafe
+let copy_sign x y = Smtml.Typed.Float32.copysign x y
 
 let eq x y = Smtml.Typed.Float32.eq x y
 
-let ne x y =
-  Smtml.Expr.relop ty Ne (Smtml.Typed.raw x) (Smtml.Typed.raw y)
-  |> Smtml.Typed.unsafe
+let ne x y = Smtml.Typed.Float32.ne x y
 
 let lt x y = Smtml.Typed.Float32.lt x y
 
@@ -51,23 +44,20 @@ let le x y = Smtml.Typed.Float32.le x y
 
 let ge x y = Smtml.Typed.Float32.ge x y
 
-let convert_i32_s x = Smtml.Expr.cvtop ty ConvertSI32 x |> Smtml.Typed.unsafe
+let convert_i32_s x = Smtml.Typed.Float32.convert_i32_s x
 
-let convert_i32_u x = Smtml.Expr.cvtop ty ConvertUI32 x |> Smtml.Typed.unsafe
+let convert_i32_u x = Smtml.Typed.Float32.convert_i32_u x
 
-let convert_i64_s x = Smtml.Expr.cvtop ty ConvertSI64 x |> Smtml.Typed.unsafe
+let convert_i64_s x = Smtml.Typed.Float32.convert_i64_s x
 
-let convert_i64_u x = Smtml.Expr.cvtop ty ConvertUI64 x |> Smtml.Typed.unsafe
+let convert_i64_u x = Smtml.Typed.Float32.convert_i64_u x
 
-let demote_f64 x =
-  Smtml.Expr.cvtop ty DemoteF64 (Smtml.Typed.raw x) |> Smtml.Typed.unsafe
+let demote_f64 x = Smtml.Typed.Float32.demote_f64 x
 
-let reinterpret_i32 x =
-  Smtml.Expr.cvtop ty Reinterpret_int x |> Smtml.Typed.unsafe
+let reinterpret_i32 x = Smtml.Typed.Float32.reinterpret_i32 x
 
-let of_bits x = Smtml.Expr.cvtop ty Reinterpret_int x |> Smtml.Typed.unsafe
+let of_bits x = Smtml.Typed.Float32.reinterpret_i32 x
 
-let to_bits x =
-  Smtml.Expr.cvtop (Ty_bitv 32) Reinterpret_float (Smtml.Typed.raw x)
+let to_bits x = Smtml.Typed.Float32.to_bv x
 
-let pp fmt x = Smtml.Expr.pp fmt (Smtml.Typed.raw x)
+let pp fmt x = Smtml.Typed.Float32.pp fmt x

--- a/src/symbolic/symbolic_f32.mli
+++ b/src/symbolic/symbolic_f32.mli
@@ -2,6 +2,6 @@ include
   F32_intf.T
     with type t = Smtml.Typed.float32 Smtml.Typed.t
      and type boolean := bool Smtml.Typed.t
-     and type i32 := Smtml.Expr.t
-     and type i64 := Smtml.Expr.t
+     and type i32 := Smtml.Typed.bitv32 Smtml.Typed.t
+     and type i64 := Smtml.Typed.bitv64 Smtml.Typed.t
      and type f64 := Smtml.Typed.float64 Smtml.Typed.t

--- a/src/symbolic/symbolic_f64.ml
+++ b/src/symbolic/symbolic_f64.ml
@@ -60,6 +60,6 @@ let of_bits x = Smtml.Typed.Float64.reinterpret_i64 x
 
 let to_bits x = Smtml.Typed.Float64.to_bv x
 
-let pp fmt x = Smtml.Typed.Float64.pp fmt x
+let pp fmt x = Smtml.Typed.Float64.pp fmt (Obj.magic x)
 
 let of_float (f : Float.t) : t = Concrete_f64.of_float f |> of_concrete

--- a/src/symbolic/symbolic_f64.ml
+++ b/src/symbolic/symbolic_f64.ml
@@ -1,7 +1,5 @@
 type t = Smtml.Typed.float64 Smtml.Typed.t
 
-let ty = Smtml.Ty.Ty_fp 64
-
 let of_concrete (f : Float64.t) : t = Smtml.Typed.Float64.v (Float64.to_bits f)
 
 let zero = of_concrete Float64.zero
@@ -12,14 +10,13 @@ let neg x = Smtml.Typed.Float64.neg x
 
 let sqrt x = Smtml.Typed.Float64.sqrt x
 
-let ceil x = Smtml.Expr.unop ty Ceil (Smtml.Typed.raw x) |> Smtml.Typed.unsafe
+let ceil x = Smtml.Typed.Float64.ceil x
 
-let floor x = Smtml.Expr.unop ty Floor (Smtml.Typed.raw x) |> Smtml.Typed.unsafe
+let floor x = Smtml.Typed.Float64.floor x
 
-let trunc x = Smtml.Expr.unop ty Trunc (Smtml.Typed.raw x) |> Smtml.Typed.unsafe
+let trunc x = Smtml.Typed.Float64.trunc x
 
-let nearest x =
-  Smtml.Expr.unop ty Nearest (Smtml.Typed.raw x) |> Smtml.Typed.unsafe
+let nearest x = Smtml.Typed.Float64.nearest x
 
 let add x y = Smtml.Typed.Float64.add x y
 
@@ -33,15 +30,11 @@ let min x y = Smtml.Typed.Float64.min x y
 
 let max x y = Smtml.Typed.Float64.max x y
 
-let copy_sign x y =
-  Smtml.Expr.binop ty Copysign (Smtml.Typed.raw x) (Smtml.Typed.raw y)
-  |> Smtml.Typed.unsafe
+let copy_sign x y = Smtml.Typed.Float64.copysign x y
 
 let eq x y = Smtml.Typed.Float64.eq x y
 
-let ne x y =
-  Smtml.Expr.relop ty Ne (Smtml.Typed.raw x) (Smtml.Typed.raw y)
-  |> Smtml.Typed.unsafe
+let ne x y = Smtml.Typed.Float64.ne x y
 
 let lt x y = Smtml.Typed.Float64.lt x y
 
@@ -51,30 +44,22 @@ let le x y = Smtml.Typed.Float64.le x y
 
 let ge x y = Smtml.Typed.Float64.ge x y
 
-let convert_i32_s (x : Smtml.Expr.t) =
-  Smtml.Expr.cvtop ty ConvertSI32 x |> Smtml.Typed.unsafe
+let convert_i32_s x = Smtml.Typed.Float64.convert_i32_s x
 
-let convert_i32_u (x : Smtml.Expr.t) =
-  Smtml.Expr.cvtop ty ConvertUI32 x |> Smtml.Typed.unsafe
+let convert_i32_u x = Smtml.Typed.Float64.convert_i32_u x
 
-let convert_i64_s (x : Smtml.Expr.t) =
-  Smtml.Expr.cvtop ty ConvertSI64 x |> Smtml.Typed.unsafe
+let convert_i64_s x = Smtml.Typed.Float64.convert_i64_s x
 
-let convert_i64_u (x : Smtml.Expr.t) =
-  Smtml.Expr.cvtop ty ConvertUI64 x |> Smtml.Typed.unsafe
+let convert_i64_u x = Smtml.Typed.Float64.convert_i64_u x
 
-let promote_f32 x =
-  Smtml.Expr.cvtop ty PromoteF32 (Smtml.Typed.raw x) |> Smtml.Typed.unsafe
+let promote_f32 x = Smtml.Typed.Float64.promote_f32 x
 
-let reinterpret_i64 (x : Smtml.Expr.t) =
-  Smtml.Expr.cvtop ty Reinterpret_int x |> Smtml.Typed.unsafe
+let reinterpret_i64 x = Smtml.Typed.Float64.reinterpret_i64 x
 
-let of_bits (x : Smtml.Expr.t) =
-  Smtml.Expr.cvtop ty Reinterpret_int x |> Smtml.Typed.unsafe
+let of_bits x = Smtml.Typed.Float64.reinterpret_i64 x
 
-let to_bits x =
-  Smtml.Expr.cvtop (Ty_bitv 64) Reinterpret_float (Smtml.Typed.raw x)
+let to_bits x = Smtml.Typed.Float64.to_bv x
 
-let pp fmt x = Smtml.Expr.pp fmt (Smtml.Typed.raw x)
+let pp fmt x = Smtml.Typed.Float64.pp fmt x
 
 let of_float (f : Float.t) : t = Concrete_f64.of_float f |> of_concrete

--- a/src/symbolic/symbolic_f64.mli
+++ b/src/symbolic/symbolic_f64.mli
@@ -2,6 +2,6 @@ include
   F64_intf.T
     with type t = Smtml.Typed.float64 Smtml.Typed.t
      and type boolean := bool Smtml.Typed.t
-     and type i32 := Smtml.Expr.t
-     and type i64 := Smtml.Expr.t
+     and type i32 := Smtml.Typed.bitv32 Smtml.Typed.t
+     and type i64 := Smtml.Typed.bitv64 Smtml.Typed.t
      and type f32 := Smtml.Typed.float32 Smtml.Typed.t

--- a/src/symbolic/symbolic_i32.ml
+++ b/src/symbolic/symbolic_i32.ml
@@ -19,36 +19,47 @@ let to_boolean (e : t) : Symbolic_boolean.t =
   | Ptr _ -> Symbolic_boolean.true_
   | Symbol { ty = Ty_bool; _ } -> Symbolic_boolean.of_expr (Smtml.Typed.raw e)
   | Cvtop (_, OfBool, cond) -> Symbolic_boolean.of_expr cond
-  | _ -> Smtml.Typed.Bitv32.to_bool e
+  | _ ->
+    (* TODO: Smtml.Typed.Bitv32.to_bool e *)
+    let e = Smtml.Expr.cvtop ty ToBool (Smtml.Typed.raw e) in
+    Symbolic_boolean.of_expr e
 
 let of_boolean (e : Symbolic_boolean.t) : t =
   match Smtml.Typed.view e with
   | Val True -> one
   | Val False -> zero
-  | _ -> Smtml.Typed.Bitv32.of_bool e
+  | _ ->
+    (* TODO: Smtml.Typed.Bitv32.of_bool e *)
+    Smtml.Expr.cvtop (Ty_bitv 32) OfBool (Smtml.Typed.raw e)
+    |> Smtml.Typed.unsafe
 
-let clz e = Smtml.Expr.unop ty Clz e
+let clz e = Smtml.Expr.unop ty Clz (Smtml.Typed.raw e) |> Smtml.Typed.unsafe
 
-let ctz e = Smtml.Expr.unop ty Ctz e
+let ctz e = Smtml.Expr.unop ty Ctz (Smtml.Typed.raw e) |> Smtml.Typed.unsafe
 
-let popcnt e = Smtml.Expr.unop ty Popcnt e
+let popcnt e =
+  Smtml.Expr.unop ty Popcnt (Smtml.Typed.raw e) |> Smtml.Typed.unsafe
 
-let add e1 e2 = Smtml.Expr.binop ty Add e1 e2
+let add e1 e2 = Smtml.Typed.Bitv32.add e1 e2
 
-let sub e1 e2 = Smtml.Expr.binop ty Sub e1 e2
+let sub e1 e2 = Smtml.Typed.Bitv32.sub e1 e2
 
-let mul e1 e2 = Smtml.Expr.binop ty Mul e1 e2
+let mul e1 e2 = Smtml.Typed.Bitv32.mul e1 e2
 
-let div e1 e2 = Smtml.Expr.binop ty Div e1 e2
+let div e1 e2 = Smtml.Typed.Bitv32.div e1 e2
 
-let unsigned_div e1 e2 = Smtml.Expr.binop ty DivU e1 e2
+let unsigned_div e1 e2 =
+  Smtml.Expr.binop ty DivU (Smtml.Typed.raw e1) (Smtml.Typed.raw e2)
+  |> Smtml.Typed.unsafe
 
-let rem e1 e2 = Smtml.Expr.binop ty Rem e1 e2
+let rem e1 e2 = Smtml.Typed.Bitv32.rem e1 e2
 
-let unsigned_rem e1 e2 = Smtml.Expr.binop ty RemU e1 e2
+let unsigned_rem e1 e2 =
+  Smtml.Expr.binop ty RemU (Smtml.Typed.raw e1) (Smtml.Typed.raw e2)
+  |> Smtml.Typed.unsafe
 
 let boolify e =
-  match Smtml.Expr.view e with
+  match Smtml.Typed.view e with
   | Val (Bitv bv) when Smtml.Bitvector.eqz bv -> Some Symbolic_boolean.false_
   | Val (Bitv bv) when Smtml.Bitvector.eq_one bv -> Some Symbolic_boolean.true_
   | Cvtop (_, OfBool, cond) -> Some (Symbolic_boolean.of_expr cond)
@@ -57,102 +68,105 @@ let boolify e =
 let logand e1 e2 =
   match (boolify e1, boolify e2) with
   | Some b1, Some b2 -> of_boolean (Symbolic_boolean.and_ b1 b2)
-  | _ -> Smtml.Expr.binop ty And e1 e2
+  | _ -> Smtml.Typed.Bitv32.logand e1 e2
 
 let logor e1 e2 =
   match (boolify e1, boolify e2) with
   | Some b1, Some b2 -> of_boolean (Symbolic_boolean.or_ b1 b2)
-  | _ -> Smtml.Expr.binop ty Or e1 e2
+  | _ -> Smtml.Typed.Bitv32.logor e1 e2
 
-let logxor e1 e2 = Smtml.Expr.binop ty Xor e1 e2
+let logxor e1 e2 = Smtml.Typed.Bitv32.logxor e1 e2
 
-let shl e1 e2 = Smtml.Expr.binop ty Shl e1 e2
+let shl e1 e2 = Smtml.Typed.Bitv32.shl e1 e2
 
-let shr_s e1 e2 = Smtml.Expr.binop ty ShrA e1 e2
+let shr_s e1 e2 = Smtml.Typed.Bitv32.ashr e1 e2
 
-let shr_u e1 e2 = Smtml.Expr.binop ty ShrL e1 e2
+let shr_u e1 e2 = Smtml.Typed.Bitv32.lshr e1 e2
 
-let rotl e1 e2 = Smtml.Expr.binop ty Rotl e1 e2
+let rotl e1 e2 = Smtml.Typed.Bitv32.rotate_left e1 e2
 
-let rotr e1 e2 = Smtml.Expr.binop ty Rotr e1 e2
+let rotr e1 e2 = Smtml.Typed.Bitv32.rotate_right e1 e2
 
 let eq_concrete (e : t) (c : Int32.t) : Symbolic_boolean.t =
-  Smtml.Expr.relop Ty_bool Eq e (of_concrete c) |> Symbolic_boolean.of_expr
+  let c = of_concrete c in
+  Smtml.Typed.Bitv32.eq c e
 
-(* TODO: why do we use `Ty_bool` in the first two cases and `ty` in the others? What is the righe choice? *)
-let eq e1 e2 : Symbolic_boolean.t =
-  Smtml.Expr.relop Ty_bool Eq e1 e2 |> Symbolic_boolean.of_expr
+let eq e1 e2 : Symbolic_boolean.t = Smtml.Typed.Bitv32.eq e1 e2
 
 let ne e1 e2 : Symbolic_boolean.t =
-  Smtml.Expr.relop Ty_bool Ne e1 e2 |> Symbolic_boolean.of_expr
+  Smtml.Expr.relop Ty_bool Ne (Smtml.Typed.raw e1) (Smtml.Typed.raw e2)
+  |> Symbolic_boolean.of_expr
 
-let lt e1 e2 : Symbolic_boolean.t =
-  Smtml.Expr.relop ty Lt e1 e2 |> Symbolic_boolean.of_expr
+let lt e1 e2 : Symbolic_boolean.t = Smtml.Typed.Bitv32.lt e1 e2
 
-let gt e1 e2 : Symbolic_boolean.t =
-  Smtml.Expr.relop ty Gt e1 e2 |> Symbolic_boolean.of_expr
+let gt e1 e2 : Symbolic_boolean.t = Smtml.Typed.Bitv32.gt e1 e2
 
-let lt_u e1 e2 : Symbolic_boolean.t =
-  Smtml.Expr.relop ty LtU e1 e2 |> Symbolic_boolean.of_expr
+let lt_u e1 e2 : Symbolic_boolean.t = Smtml.Typed.Bitv32.lt_u e1 e2
 
-let gt_u e1 e2 : Symbolic_boolean.t =
-  Smtml.Expr.relop ty GtU e1 e2 |> Symbolic_boolean.of_expr
+let gt_u e1 e2 : Symbolic_boolean.t = Smtml.Typed.Bitv32.gt_u e1 e2
 
-let le e1 e2 : Symbolic_boolean.t =
-  Smtml.Expr.relop ty Le e1 e2 |> Symbolic_boolean.of_expr
+let le e1 e2 : Symbolic_boolean.t = Smtml.Typed.Bitv32.le e1 e2
 
-let ge e1 e2 : Symbolic_boolean.t =
-  Smtml.Expr.relop ty Ge e1 e2 |> Symbolic_boolean.of_expr
+let ge e1 e2 : Symbolic_boolean.t = Smtml.Typed.Bitv32.ge e1 e2
 
-let le_u e1 e2 : Symbolic_boolean.t =
-  Smtml.Expr.relop ty LeU e1 e2 |> Symbolic_boolean.of_expr
+let le_u e1 e2 : Symbolic_boolean.t = Smtml.Typed.Bitv32.le_u e1 e2
 
-let ge_u e1 e2 : Symbolic_boolean.t =
-  Smtml.Expr.relop ty GeU e1 e2 |> Symbolic_boolean.of_expr
+let ge_u e1 e2 : Symbolic_boolean.t = Smtml.Typed.Bitv32.ge_u e1 e2
 
 let trunc_f32_s x =
-  try Ok (Smtml.Expr.cvtop ty TruncSF32 (Smtml.Typed.raw x))
+  try
+    Ok (Smtml.Expr.cvtop ty TruncSF32 (Smtml.Typed.raw x) |> Smtml.Typed.unsafe)
   with
   | Smtml.Eval.Eval_error ((`Integer_overflow | `Conversion_to_integer) as e) ->
     Error e
 
 let trunc_f32_u x =
-  try Ok (Smtml.Expr.cvtop ty TruncUF32 (Smtml.Typed.raw x))
+  try
+    Ok (Smtml.Expr.cvtop ty TruncUF32 (Smtml.Typed.raw x) |> Smtml.Typed.unsafe)
   with
   | Smtml.Eval.Eval_error ((`Integer_overflow | `Conversion_to_integer) as e) ->
     Error e
 
 let trunc_f64_s x =
-  try Ok (Smtml.Expr.cvtop ty TruncSF64 (Smtml.Typed.raw x))
+  try
+    Ok (Smtml.Expr.cvtop ty TruncSF64 (Smtml.Typed.raw x) |> Smtml.Typed.unsafe)
   with
   | Smtml.Eval.Eval_error ((`Integer_overflow | `Conversion_to_integer) as e) ->
     Error e
 
 let trunc_f64_u x =
-  try Ok (Smtml.Expr.cvtop ty TruncUF64 (Smtml.Typed.raw x))
+  try
+    Ok (Smtml.Expr.cvtop ty TruncUF64 (Smtml.Typed.raw x) |> Smtml.Typed.unsafe)
   with
   | Smtml.Eval.Eval_error ((`Integer_overflow | `Conversion_to_integer) as e) ->
     Error e
 
-let trunc_sat_f32_s x = Smtml.Expr.cvtop ty Trunc_sat_f32_s (Smtml.Typed.raw x)
+let trunc_sat_f32_s x =
+  Smtml.Expr.cvtop ty Trunc_sat_f32_s (Smtml.Typed.raw x) |> Smtml.Typed.unsafe
 
-let trunc_sat_f32_u x = Smtml.Expr.cvtop ty Trunc_sat_f32_u (Smtml.Typed.raw x)
+let trunc_sat_f32_u x =
+  Smtml.Expr.cvtop ty Trunc_sat_f32_u (Smtml.Typed.raw x) |> Smtml.Typed.unsafe
 
-let trunc_sat_f64_s x = Smtml.Expr.cvtop ty Trunc_sat_f64_s (Smtml.Typed.raw x)
+let trunc_sat_f64_s x =
+  Smtml.Expr.cvtop ty Trunc_sat_f64_s (Smtml.Typed.raw x) |> Smtml.Typed.unsafe
 
-let trunc_sat_f64_u x = Smtml.Expr.cvtop ty Trunc_sat_f64_u (Smtml.Typed.raw x)
+let trunc_sat_f64_u x =
+  Smtml.Expr.cvtop ty Trunc_sat_f64_u (Smtml.Typed.raw x) |> Smtml.Typed.unsafe
 
 let reinterpret_f32 x =
   Smtml.Expr.cvtop ty Reinterpret_float (Smtml.Typed.raw x)
+  |> Smtml.Typed.unsafe
 
-let wrap_i64 x = Smtml.Expr.cvtop ty WrapI64 x
+let wrap_i64 x =
+  Smtml.Expr.cvtop ty WrapI64 (Smtml.Typed.raw x) |> Smtml.Typed.unsafe
 
 (* FIXME: This is probably wrong? *)
 let extend_s n x =
   Smtml.Expr.cvtop ty
     (Sign_extend (32 - n))
-    (Smtml.Expr.extract x ~high:(n / 8) ~low:0)
+    (Smtml.Expr.extract (Smtml.Typed.raw x) ~high:(n / 8) ~low:0)
+  |> Smtml.Typed.unsafe
 
-let pp = Smtml.Expr.pp
+let pp fmt x = Smtml.Typed.Bitv32.pp fmt x
 
-let symbol s = Smtml.Expr.symbol s
+let symbol s = Smtml.Expr.symbol s |> Smtml.Typed.unsafe

--- a/src/symbolic/symbolic_i32.ml
+++ b/src/symbolic/symbolic_i32.ml
@@ -1,9 +1,9 @@
-type t = Smtml.Expr.t
+type t = Smtml.Typed.bitv32 Smtml.Typed.t
 
 let ty = Smtml.Ty.Ty_bitv 32
 
 let of_concrete (i : Int32.t) : t =
-  Smtml.Expr.value (Bitv (Smtml.Bitvector.of_int32 i))
+  Smtml.Typed.Bitv32.v (Smtml.Bitvector.of_int32 i)
 
 let of_int (i : int) : t = of_concrete (Int32.of_int i)
 
@@ -12,24 +12,20 @@ let zero = of_concrete 0l
 let one = of_concrete 1l
 
 let to_boolean (e : t) : Symbolic_boolean.t =
-  match Smtml.Expr.view e with
+  match Smtml.Typed.view e with
   | Val (Bitv bv) ->
     if Smtml.Bitvector.eqz bv then Symbolic_boolean.false_
     else Symbolic_boolean.true_
   | Ptr _ -> Symbolic_boolean.true_
-  | Symbol { ty = Ty_bool; _ } -> Symbolic_boolean.of_expr e
+  | Symbol { ty = Ty_bool; _ } -> Symbolic_boolean.of_expr (Smtml.Typed.raw e)
   | Cvtop (_, OfBool, cond) -> Symbolic_boolean.of_expr cond
-  | _ ->
-    let e = Smtml.Expr.cvtop ty ToBool e in
-    Symbolic_boolean.of_expr e
+  | _ -> Smtml.Typed.Bitv32.to_bool e
 
 let of_boolean (e : Symbolic_boolean.t) : t =
-  let e = Symbolic_boolean.to_expr e in
-  match Smtml.Expr.view e with
+  match Smtml.Typed.view e with
   | Val True -> one
   | Val False -> zero
-  | Cvtop (Ty_bitv 32, ToBool, e') -> e'
-  | _ -> Smtml.Expr.cvtop (Ty_bitv 32) OfBool e
+  | _ -> Smtml.Typed.Bitv32.of_bool e
 
 let clz e = Smtml.Expr.unop ty Clz e
 

--- a/src/symbolic/symbolic_i32.mli
+++ b/src/symbolic/symbolic_i32.mli
@@ -1,8 +1,8 @@
 include
   I32_intf.T
-    with type t = Smtml.Expr.t
+    with type t = Smtml.Typed.bitv32 Smtml.Typed.t
      and type boolean := bool Smtml.Typed.t
-     and type i64 := Smtml.Expr.t
+     and type i64 := Smtml.Typed.bitv64 Smtml.Typed.t
      and type f32 := Smtml.Typed.float32 Smtml.Typed.t
      and type f64 := Smtml.Typed.float64 Smtml.Typed.t
 

--- a/src/symbolic/symbolic_i64.ml
+++ b/src/symbolic/symbolic_i64.ml
@@ -1,121 +1,143 @@
-type t = Smtml.Expr.t
+type t = Smtml.Typed.bitv64 Smtml.Typed.t
 
 let ty = Smtml.Ty.Ty_bitv 64
 
 let of_concrete (i : Int64.t) : t =
-  Smtml.Expr.value (Bitv (Smtml.Bitvector.of_int64 i))
+  Smtml.Typed.Bitv64.v (Smtml.Bitvector.of_int64 i)
 
 let of_int (i : int) : t = of_concrete (Int64.of_int i)
 
 let zero = of_concrete 0L
 
-let clz e = Smtml.Expr.unop ty Clz e
+let clz e = Smtml.Expr.unop ty Clz (Smtml.Typed.raw e) |> Smtml.Typed.unsafe
 
-let ctz e = Smtml.Expr.unop ty Ctz e
+let ctz e = Smtml.Expr.unop ty Ctz (Smtml.Typed.raw e) |> Smtml.Typed.unsafe
 
-let popcnt e = Smtml.Expr.unop ty Popcnt e
+let popcnt e =
+  Smtml.Expr.unop ty Popcnt (Smtml.Typed.raw e) |> Smtml.Typed.unsafe
 
-let add e1 e2 = Smtml.Expr.binop ty Add e1 e2
+let add e1 e2 = Smtml.Typed.Bitv64.add e1 e2
 
-let sub e1 e2 = Smtml.Expr.binop ty Sub e1 e2
+let sub e1 e2 = Smtml.Typed.Bitv64.sub e1 e2
 
-let mul e1 e2 = Smtml.Expr.binop ty Mul e1 e2
+let mul e1 e2 = Smtml.Typed.Bitv64.mul e1 e2
 
-let div e1 e2 = Smtml.Expr.binop ty Div e1 e2
+let div e1 e2 = Smtml.Typed.Bitv64.div e1 e2
 
-let unsigned_div e1 e2 = Smtml.Expr.binop ty DivU e1 e2
+let unsigned_div e1 e2 =
+  Smtml.Expr.binop ty DivU (Smtml.Typed.raw e1) (Smtml.Typed.raw e2)
+  |> Smtml.Typed.unsafe
 
-let rem e1 e2 = Smtml.Expr.binop ty Rem e1 e2
+let rem e1 e2 = Smtml.Typed.Bitv64.rem e1 e2
 
-let unsigned_rem e1 e2 = Smtml.Expr.binop ty RemU e1 e2
+let unsigned_rem e1 e2 =
+  Smtml.Expr.binop ty RemU (Smtml.Typed.raw e1) (Smtml.Typed.raw e2)
+  |> Smtml.Typed.unsafe
 
-let logand e1 e2 = Smtml.Expr.binop ty And e1 e2
+let logand e1 e2 = Smtml.Typed.Bitv64.logand e1 e2
 
-let logor e1 e2 = Smtml.Expr.binop ty Or e1 e2
+let logor e1 e2 = Smtml.Typed.Bitv64.logor e1 e2
 
-let logxor e1 e2 = Smtml.Expr.binop ty Xor e1 e2
+let logxor e1 e2 = Smtml.Typed.Bitv64.logxor e1 e2
 
-let shl e1 e2 = Smtml.Expr.binop ty Shl e1 e2
+let shl e1 e2 = Smtml.Typed.Bitv64.shl e1 e2
 
-let shr_s e1 e2 = Smtml.Expr.binop ty ShrA e1 e2
+let shr_s e1 e2 = Smtml.Typed.Bitv64.ashr e1 e2
 
-let shr_u e1 e2 = Smtml.Expr.binop ty ShrL e1 e2
+let shr_u e1 e2 = Smtml.Typed.Bitv64.lshr e1 e2
 
-let rotl e1 e2 = Smtml.Expr.binop ty Rotl e1 e2
+let rotl e1 e2 = Smtml.Typed.Bitv64.rotate_left e1 e2
 
-let rotr e1 e2 = Smtml.Expr.binop ty Rotr e1 e2
+let rotr e1 e2 = Smtml.Typed.Bitv64.rotate_right e1 e2
 
-(* TODO: same as i32, why do we use `Ty_bool` sometimes and `ty` in other places? *)
-let eq_concrete (e : t) (c : Int64.t) =
-  Smtml.Expr.relop Ty_bool Eq e (of_concrete c) |> Symbolic_boolean.of_expr
+let eq_concrete (e : t) (c : Int64.t) : Symbolic_boolean.t =
+  let c = of_concrete c in
+  Smtml.Typed.Bitv64.eq c e
 
-let eq e1 e2 = Smtml.Expr.relop Ty_bool Eq e1 e2 |> Symbolic_boolean.of_expr
+let eq e1 e2 : Symbolic_boolean.t = Smtml.Typed.Bitv64.eq e1 e2
 
-let ne e1 e2 = Smtml.Expr.relop Ty_bool Ne e1 e2 |> Symbolic_boolean.of_expr
+let ne e1 e2 : Symbolic_boolean.t =
+  Smtml.Expr.relop Ty_bool Ne (Smtml.Typed.raw e1) (Smtml.Typed.raw e2)
+  |> Symbolic_boolean.of_expr
 
-let lt e1 e2 = Smtml.Expr.relop ty Lt e1 e2 |> Symbolic_boolean.of_expr
+let lt e1 e2 : Symbolic_boolean.t = Smtml.Typed.Bitv64.lt e1 e2
 
-let gt e1 e2 = Smtml.Expr.relop ty Gt e1 e2 |> Symbolic_boolean.of_expr
+let gt e1 e2 : Symbolic_boolean.t = Smtml.Typed.Bitv64.gt e1 e2
 
-let lt_u e1 e2 = Smtml.Expr.relop ty LtU e1 e2 |> Symbolic_boolean.of_expr
+let lt_u e1 e2 : Symbolic_boolean.t = Smtml.Typed.Bitv64.lt_u e1 e2
 
-let gt_u e1 e2 = Smtml.Expr.relop ty GtU e1 e2 |> Symbolic_boolean.of_expr
+let gt_u e1 e2 : Symbolic_boolean.t = Smtml.Typed.Bitv64.gt_u e1 e2
 
-let le e1 e2 = Smtml.Expr.relop ty Le e1 e2 |> Symbolic_boolean.of_expr
+let le e1 e2 : Symbolic_boolean.t = Smtml.Typed.Bitv64.le e1 e2
 
-let ge e1 e2 = Smtml.Expr.relop ty Ge e1 e2 |> Symbolic_boolean.of_expr
+let ge e1 e2 : Symbolic_boolean.t = Smtml.Typed.Bitv64.ge e1 e2
 
-let le_u e1 e2 = Smtml.Expr.relop ty LeU e1 e2 |> Symbolic_boolean.of_expr
+let le_u e1 e2 : Symbolic_boolean.t = Smtml.Typed.Bitv64.le_u e1 e2
 
-let ge_u e1 e2 = Smtml.Expr.relop ty GeU e1 e2 |> Symbolic_boolean.of_expr
+let ge_u e1 e2 : Symbolic_boolean.t = Smtml.Typed.Bitv64.ge_u e1 e2
 
-let of_int32 e = Smtml.Expr.cvtop ty (Sign_extend 32) e
+let of_int32 e =
+  Smtml.Expr.cvtop ty (Sign_extend 32) (Smtml.Typed.raw e) |> Smtml.Typed.unsafe
 
-let to_int32 e = Smtml.Expr.cvtop (Ty_bitv 32) WrapI64 e
+let to_int32 e =
+  Smtml.Expr.cvtop (Ty_bitv 32) WrapI64 (Smtml.Typed.raw e)
+  |> Smtml.Typed.unsafe
 
 let trunc_f32_s x =
-  try Ok (Smtml.Expr.cvtop ty TruncSF32 (Smtml.Typed.raw x))
+  try
+    Ok (Smtml.Expr.cvtop ty TruncSF32 (Smtml.Typed.raw x) |> Smtml.Typed.unsafe)
   with
   | Smtml.Eval.Eval_error ((`Integer_overflow | `Conversion_to_integer) as e) ->
     Error e
 
 let trunc_f32_u x =
-  try Ok (Smtml.Expr.cvtop ty TruncUF32 (Smtml.Typed.raw x))
+  try
+    Ok (Smtml.Expr.cvtop ty TruncUF32 (Smtml.Typed.raw x) |> Smtml.Typed.unsafe)
   with
   | Smtml.Eval.Eval_error ((`Integer_overflow | `Conversion_to_integer) as e) ->
     Error e
 
 let trunc_f64_s x =
-  try Ok (Smtml.Expr.cvtop ty TruncSF64 (Smtml.Typed.raw x))
+  try
+    Ok (Smtml.Expr.cvtop ty TruncSF64 (Smtml.Typed.raw x) |> Smtml.Typed.unsafe)
   with
   | Smtml.Eval.Eval_error ((`Integer_overflow | `Conversion_to_integer) as e) ->
     Error e
 
 let trunc_f64_u x =
-  try Ok (Smtml.Expr.cvtop ty TruncUF64 (Smtml.Typed.raw x))
+  try
+    Ok (Smtml.Expr.cvtop ty TruncUF64 (Smtml.Typed.raw x) |> Smtml.Typed.unsafe)
   with
   | Smtml.Eval.Eval_error ((`Integer_overflow | `Conversion_to_integer) as e) ->
     Error e
 
-let trunc_sat_f32_s x = Smtml.Expr.cvtop ty Trunc_sat_f32_s (Smtml.Typed.raw x)
+let trunc_sat_f32_s x =
+  Smtml.Expr.cvtop ty Trunc_sat_f32_s (Smtml.Typed.raw x) |> Smtml.Typed.unsafe
 
-let trunc_sat_f32_u x = Smtml.Expr.cvtop ty Trunc_sat_f32_u (Smtml.Typed.raw x)
+let trunc_sat_f32_u x =
+  Smtml.Expr.cvtop ty Trunc_sat_f32_u (Smtml.Typed.raw x) |> Smtml.Typed.unsafe
 
-let trunc_sat_f64_s x = Smtml.Expr.cvtop ty Trunc_sat_f64_s (Smtml.Typed.raw x)
+let trunc_sat_f64_s x =
+  Smtml.Expr.cvtop ty Trunc_sat_f64_s (Smtml.Typed.raw x) |> Smtml.Typed.unsafe
 
-let trunc_sat_f64_u x = Smtml.Expr.cvtop ty Trunc_sat_f64_u (Smtml.Typed.raw x)
+let trunc_sat_f64_u x =
+  Smtml.Expr.cvtop ty Trunc_sat_f64_u (Smtml.Typed.raw x) |> Smtml.Typed.unsafe
 
 let reinterpret_f64 x =
   Smtml.Expr.cvtop ty Reinterpret_float (Smtml.Typed.raw x)
+  |> Smtml.Typed.unsafe
 
 (* FIXME: This is probably wrong? *)
 let extend_s n x =
   Smtml.Expr.cvtop ty
     (Sign_extend (64 - n))
-    (Smtml.Expr.extract x ~high:(n / 8) ~low:0)
+    (Smtml.Expr.extract (Smtml.Typed.raw x) ~high:(n / 8) ~low:0)
+  |> Smtml.Typed.unsafe
 
-let extend_i32_s x = Smtml.Expr.cvtop ty (Sign_extend 32) x
+let extend_i32_s x =
+  Smtml.Expr.cvtop ty (Sign_extend 32) (Smtml.Typed.raw x) |> Smtml.Typed.unsafe
 
-let extend_i32_u x = Smtml.Expr.cvtop ty (Zero_extend 32) x
+let extend_i32_u x =
+  Smtml.Expr.cvtop ty (Zero_extend 32) (Smtml.Typed.raw x) |> Smtml.Typed.unsafe
 
-let pp = Smtml.Expr.pp
+let pp fmt x = Smtml.Typed.Bitv64.pp fmt x

--- a/src/symbolic/symbolic_i64.mli
+++ b/src/symbolic/symbolic_i64.mli
@@ -1,7 +1,7 @@
 include
   I64_intf.T
-    with type t = Smtml.Expr.t
+    with type t = Smtml.Typed.bitv64 Smtml.Typed.t
      and type boolean := bool Smtml.Typed.t
-     and type i32 := Smtml.Expr.t
+     and type i32 := Smtml.Typed.bitv32 Smtml.Typed.t
      and type f32 := Smtml.Typed.float32 Smtml.Typed.t
      and type f64 := Smtml.Typed.float64 Smtml.Typed.t

--- a/src/symbolic/symbolic_memory.mli
+++ b/src/symbolic/symbolic_memory.mli
@@ -14,8 +14,11 @@ include
 val replace : t -> unit Symbolic_choice.t
 
 val realloc :
-  t -> ptr:Smtml.Expr.t -> size:Smtml.Expr.t -> Smtml.Expr.t Symbolic_choice.t
+     t
+  -> ptr:Symbolic_i32.t
+  -> size:Symbolic_i32.t
+  -> Symbolic_i32.t Symbolic_choice.t
 
-val free : t -> Smtml.Expr.t -> Smtml.Expr.t Symbolic_choice.t
+val free : t -> Symbolic_i32.t -> Symbolic_i32.t Symbolic_choice.t
 
 val of_concrete : env_id:int -> id:int -> Concrete_memory.t -> t

--- a/src/symbolic/symbolic_v128.ml
+++ b/src/symbolic/symbolic_v128.ml
@@ -6,25 +6,29 @@ type t = Smtml.Expr.t
 
 let of_concrete (v : Concrete_v128.t) : t =
   let a, b = Concrete_v128.to_i64x2 v in
-  Smtml.Expr.concat (Symbolic_i64.of_concrete a) (Symbolic_i64.of_concrete b)
+  Smtml.Expr.concat
+    (Symbolic_i64.of_concrete a |> Smtml.Typed.raw)
+    (Symbolic_i64.of_concrete b |> Smtml.Typed.raw)
 
 let zero : t = of_concrete Concrete_v128.zero
 
 let of_i32x4 a b c d =
-  Smtml.Expr.concat (Smtml.Expr.concat a b) (Smtml.Expr.concat c d)
+  Smtml.Expr.concat
+    (Smtml.Expr.concat (Smtml.Typed.raw a) (Smtml.Typed.raw b))
+    (Smtml.Expr.concat (Smtml.Typed.raw c) (Smtml.Typed.raw d))
 
 let to_i32x4 v =
-  let a = Smtml.Expr.extract v ~low:12 ~high:16 in
-  let b = Smtml.Expr.extract v ~low:8 ~high:12 in
-  let c = Smtml.Expr.extract v ~low:4 ~high:8 in
-  let d = Smtml.Expr.extract v ~low:0 ~high:4 in
+  let a = Smtml.Expr.extract v ~low:12 ~high:16 |> Smtml.Typed.unsafe in
+  let b = Smtml.Expr.extract v ~low:8 ~high:12 |> Smtml.Typed.unsafe in
+  let c = Smtml.Expr.extract v ~low:4 ~high:8 |> Smtml.Typed.unsafe in
+  let d = Smtml.Expr.extract v ~low:0 ~high:4 |> Smtml.Typed.unsafe in
   (a, b, c, d)
 
-let of_i64x2 a b = Smtml.Expr.concat a b
+let of_i64x2 a b = Smtml.Expr.concat (Smtml.Typed.raw a) (Smtml.Typed.raw b)
 
 let to_i64x2 v =
-  let a = Smtml.Expr.extract v ~low:8 ~high:16 in
-  let b = Smtml.Expr.extract v ~low:0 ~high:8 in
+  let a = Smtml.Expr.extract v ~low:8 ~high:16 |> Smtml.Typed.unsafe in
+  let b = Smtml.Expr.extract v ~low:0 ~high:8 |> Smtml.Typed.unsafe in
   (a, b)
 
 let pp ppf v = Smtml.Expr.pp ppf v

--- a/src/symbolic/symbolic_value.ml
+++ b/src/symbolic/symbolic_value.ml
@@ -12,9 +12,9 @@ module Ref = Symbolic_ref
 
 type boolean = bool Smtml.Typed.t
 
-type i32 = I32.t
+type i32 = Smtml.Typed.bitv32 Smtml.Typed.t
 
-type i64 = I64.t
+type i64 = Smtml.Typed.bitv64 Smtml.Typed.t
 
 type f32 = Smtml.Typed.float32 Smtml.Typed.t
 
@@ -23,8 +23,8 @@ type f64 = Smtml.Typed.float64 Smtml.Typed.t
 type v128 = V128.t
 
 type t =
-  | I32 of I32.t
-  | I64 of I64.t
+  | I32 of Smtml.Typed.bitv32 Smtml.Typed.t
+  | I64 of Smtml.Typed.bitv64 Smtml.Typed.t
   | F32 of Smtml.Typed.float32 Smtml.Typed.t
   | F64 of Smtml.Typed.float64 Smtml.Typed.t
   | V128 of V128.t

--- a/src/symbolic/symbolic_value.mli
+++ b/src/symbolic/symbolic_value.mli
@@ -5,8 +5,8 @@
 include
   Value_intf.T
     with type boolean = bool Smtml.Typed.t
-     and type i32 = Smtml.Expr.t
-     and type i64 = Smtml.Expr.t
+     and type i32 = Smtml.Typed.bitv32 Smtml.Typed.t
+     and type i64 = Smtml.Typed.bitv64 Smtml.Typed.t
      and type f32 = Smtml.Typed.float32 Smtml.Typed.t
      and type f64 = Smtml.Typed.float64 Smtml.Typed.t
      and type v128 = Smtml.Expr.t


### PR DESCRIPTION
I added the missing floating point operators and then started the bitvectors as well. But in the mean time some stuff came up that I had to deal with. So I won't come back to this until the evening.

You don't need to merge this as it isn't compiling atm. I was just using it to inform me of the missing operators needed for bitvectors